### PR TITLE
feat: using current_timestamp instead of current_datetime

### DIFF
--- a/dim/models/dim_check_type/templates/column_length.sql.jinja
+++ b/dim/models/dim_check_type/templates/column_length.sql.jinja
@@ -20,6 +20,6 @@ SELECT
     CAST('{{ params.alert_enabled }}' AS BOOL) AS alert_enabled,
     CAST('{{ params.alert_muted }}' AS BOOL) AS alert_muted,
     '{{ params.run_id }}' AS run_id,
-    CURRENT_DATETIME() AS actual_run_date,
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date,
     '[[dim_check_sql]]' AS dim_check_sql,
 FROM CTE

--- a/dim/models/dim_check_type/templates/column_sum_not_zero.sql.jinja
+++ b/dim/models/dim_check_type/templates/column_sum_not_zero.sql.jinja
@@ -19,6 +19,6 @@ SELECT
     CAST('{{ params.alert_enabled }}' AS BOOL) AS alert_enabled,
     CAST('{{ params.alert_muted }}' AS BOOL) AS alert_muted,
     '{{ params.run_id }}' AS run_id,
-    CURRENT_DATETIME() AS actual_run_date,
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date,
     '[[dim_check_sql]]' AS dim_check_sql,
 FROM CTE

--- a/dim/models/dim_check_type/templates/combined_column_uniqueness.sql.jinja
+++ b/dim/models/dim_check_type/templates/combined_column_uniqueness.sql.jinja
@@ -20,6 +20,6 @@ SELECT
     CAST('{{ params.alert_enabled }}' AS BOOL) AS alert_enabled,
     CAST('{{ params.alert_muted }}' AS BOOL) AS alert_muted,
     '{{ params.run_id }}' AS run_id,
-    CURRENT_DATETIME() AS actual_run_date,
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date,
     '[[dim_check_sql]]' AS dim_check_sql,
 FROM CTE

--- a/dim/models/dim_check_type/templates/compare_row_count_to_table.sql.jinja
+++ b/dim/models/dim_check_type/templates/compare_row_count_to_table.sql.jinja
@@ -19,6 +19,6 @@ SELECT
     CAST('{{ params.alert_enabled }}' AS BOOL) AS alert_enabled,
     CAST('{{ params.alert_muted }}' AS BOOL) AS alert_muted,
     '{{ params.run_id }}' AS run_id,
-    CURRENT_DATETIME() AS actual_run_date,
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date,
     '[[dim_check_sql]]' AS dim_check_sql,
 FROM CTE

--- a/dim/models/dim_check_type/templates/custom_sql_metric.sql.jinja
+++ b/dim/models/dim_check_type/templates/custom_sql_metric.sql.jinja
@@ -17,6 +17,6 @@ SELECT
     CAST('{{ params.alert_enabled }}' AS BOOL) AS alert_enabled,
     CAST('{{ params.alert_muted }}' AS BOOL) AS alert_muted,
     '{{ params.run_id }}' AS run_id,
-    CURRENT_DATETIME() AS actual_run_date,
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date,
     '[[dim_check_sql]]' AS dim_check_sql,
 FROM CTE

--- a/dim/models/dim_check_type/templates/matches_regex.sql.jinja
+++ b/dim/models/dim_check_type/templates/matches_regex.sql.jinja
@@ -21,6 +21,6 @@ SELECT
     CAST('{{ params.alert_enabled }}' AS BOOL) AS alert_enabled,
     CAST('{{ params.alert_muted }}' AS BOOL) AS alert_muted,
     '{{ params.run_id }}' AS run_id,
-    CURRENT_DATETIME() AS actual_run_date,
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date,
     '[[dim_check_sql]]' AS dim_check_sql,
 FROM CTE

--- a/dim/models/dim_check_type/templates/not_null.sql.jinja
+++ b/dim/models/dim_check_type/templates/not_null.sql.jinja
@@ -21,6 +21,6 @@ SELECT
     CAST('{{ params.alert_enabled }}' AS BOOL) AS alert_enabled,
     CAST('{{ params.alert_muted }}' AS BOOL) AS alert_muted,
     '{{ params.run_id }}' AS run_id,
-    CURRENT_DATETIME() AS actual_run_date,
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date,
     '[[dim_check_sql]]' AS dim_check_sql,
 FROM CTE

--- a/dim/models/dim_check_type/templates/numeric_values_matches.sql.jinja
+++ b/dim/models/dim_check_type/templates/numeric_values_matches.sql.jinja
@@ -20,6 +20,6 @@ SELECT
     CAST('{{ params.alert_enabled }}' AS BOOL) AS alert_enabled,
     CAST('{{ params.alert_muted }}' AS BOOL) AS alert_muted,
     '{{ params.run_id }}' AS run_id,
-    CURRENT_DATETIME() AS actual_run_date,
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date,
     '[[dim_check_sql]]' AS dim_check_sql,
 FROM CTE

--- a/dim/models/dim_check_type/templates/table_row_count.sql.jinja
+++ b/dim/models/dim_check_type/templates/table_row_count.sql.jinja
@@ -19,6 +19,6 @@ SELECT
     CAST('{{ params.alert_enabled }}' AS BOOL) AS alert_enabled,
     CAST('{{ params.alert_muted }}' AS BOOL) AS alert_muted,
     '{{ params.run_id }}' AS run_id,
-    CURRENT_DATETIME() AS actual_run_date,
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date,
     '[[dim_check_sql]]' AS dim_check_sql,
 FROM CTE

--- a/dim/models/dim_check_type/templates/template.sql.jinja
+++ b/dim/models/dim_check_type/templates/template.sql.jinja
@@ -19,6 +19,6 @@ SELECT
     CAST('{{ params.alert_enabled }}' AS BOOL) AS alert_enabled,
     CAST('{{ params.alert_muted }}' AS BOOL) AS alert_muted,
     '{{ params.run_id }}' AS run_id,
-    CURRENT_DATETIME() AS actual_run_date,
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date,
     '[[dim_check_sql]]' AS dim_check_sql,
 FROM CTE

--- a/dim/models/dim_check_type/templates/uniqueness.sql.jinja
+++ b/dim/models/dim_check_type/templates/uniqueness.sql.jinja
@@ -23,6 +23,6 @@ SELECT
     CAST('{{ params.alert_enabled }}' AS BOOL) AS alert_enabled,
     CAST('{{ params.alert_muted }}' AS BOOL) AS alert_muted,
     '{{ params.run_id }}' AS run_id,
-    CURRENT_DATETIME() AS actual_run_date,
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date,
     '[[dim_check_sql]]' AS dim_check_sql,
 FROM CTE

--- a/dim/models/dim_check_type/templates/value_in_set.sql.jinja
+++ b/dim/models/dim_check_type/templates/value_in_set.sql.jinja
@@ -20,6 +20,6 @@ SELECT
     CAST('{{ params.alert_enabled }}' AS BOOL) AS alert_enabled,
     CAST('{{ params.alert_muted }}' AS BOOL) AS alert_muted,
     '{{ params.run_id }}' AS run_id,
-    CURRENT_DATETIME() AS actual_run_date,
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date,
     '[[dim_check_sql]]' AS dim_check_sql,
 FROM CTE

--- a/tests/dim_checks/test_not_null/test_not_null.py
+++ b/tests/dim_checks/test_not_null/test_not_null.py
@@ -57,7 +57,7 @@
 #             'not_null" AS dim_check_type,
 #             '{"email": "akommasani@mozilla.com"}' AS dataset_owner,
 #             'true' AS alerts_enabled,
-#             CURRENT_DATETIME() AS actual_run_date
+#             TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date
 #         FROM CTE"""
 #     )
 

--- a/tests/dim_checks/test_uniqueness/test_uniqueness.py
+++ b/tests/dim_checks/test_uniqueness/test_uniqueness.py
@@ -58,7 +58,7 @@
 #             "uniqueness" AS dim_check_type,
 #             "akommasani@mozilla.com" AS dataset_owner,
 #             "" AS alerts_enabled,
-#             CURRENT_DATETIME() AS actual_run_date
+#             TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), SECOND) AS actual_run_date
 #         FROM CTE
 #         WHERE row_count >= 1"""
 #     )


### PR DESCRIPTION
# feat: using current_timestamp instead of current_datetime

This is to make the field timezone aware.