### PR TITLE
bug: updated locale regex to include 2 char values which are also valid

### DIFF
--- a/dim_checks/data-monitoring-dev/dim/dim_muted_alerts_v1/dim_checks.yaml
+++ b/dim_checks/data-monitoring-dev/dim/dim_muted_alerts_v1/dim_checks.yaml
@@ -56,4 +56,4 @@ dim_config:
       params:
         columns:
           - locale
-        regex: ^[a-z]{2}-[A-Z]{2}$  # example: en-GB
+        regex:  ^[a-z]{2}(-[A-Z]{2})?$ # example: en-GB or tr

--- a/dim_checks/moz-fx-data-shared-prod/org_mozilla_fenix_nightly/baseline_clients_last_seen/dim_checks.yaml
+++ b/dim_checks/moz-fx-data-shared-prod/org_mozilla_fenix_nightly/baseline_clients_last_seen/dim_checks.yaml
@@ -91,7 +91,7 @@ dim_config:
       params:
         columns:
           - locale
-        regex: ^[a-z]{2}-[A-Z]{2}$  # example: en-GB
+        regex:  ^[a-z]{2}(-[A-Z]{2})?$ # example: en-GB or tr
     - type: matches_regex
       params:
         columns:

--- a/dim_checks/moz-fx-data-shared-prod/telemetry/cohort_daily_statistics/dim_checks.yaml
+++ b/dim_checks/moz-fx-data-shared-prod/telemetry/cohort_daily_statistics/dim_checks.yaml
@@ -89,4 +89,4 @@ dim_config:
       params:
         columns:
           - locale
-        regex: ^[a-z]{2}-[A-Z]{2}$  # example: en-GB
+        regex:  ^[a-z]{2}(-[A-Z]{2})?$ # example: en-GB or tr

--- a/dim_checks/moz-fx-data-shared-prod/telemetry/rolling_cohorts/dim_checks.yaml
+++ b/dim_checks/moz-fx-data-shared-prod/telemetry/rolling_cohorts/dim_checks.yaml
@@ -94,4 +94,4 @@ dim_config:
       params:
         columns:
           - locale
-        regex: ^[a-z]{2}-[A-Z]{2}$  # example: en-GB
+        regex:  ^[a-z]{2}(-[A-Z]{2})?$ # example: en-GB or tr

--- a/docs/dim_test_types.md
+++ b/docs/dim_test_types.md
@@ -176,7 +176,7 @@ Example:
   params:
     columns:
       - locale
-    regex: ^[a-z]{2}-[A-Z]{2}$  # example: en-GB
+    regex:  ^[a-z]{2}(-[A-Z]{2})?$ # example: en-GB or tr
 ```
 
 _Note_ Due to some issues, as a workaround the regex stored inside `dim_check_context` (`dim_run_history_v1` table) contains double escape characters. Actual regex used only one, so the example above would looks like this in the table: `^\\w{2}-\\w{2}$` instead of `^\w{2}-\w{2}$`.


### PR DESCRIPTION
bug: updated locale regex to include 2 char values which are also valid

valid formats:
- `en-GB`
- `en`