### PR TITLE
fixing dependency tree, no need for deploy to rely on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,6 @@ workflows:
       - deploy:
           context: data-eng-airflow-gcr
           requires:
-            - build
             - test-unit
             - test-format
             - test-linter


### PR DESCRIPTION
# fixing dependency tree, no need for deploy to rely on build

This is because the prior test steps need to succeed prior to deploy and they depend on build.