### PR TITLE
Use `main_v5` instead of `main_v4`

### DIFF
--- a/dim_checks/mozdata/firefox_desktop/active_users_aggregates/dim_checks.yaml
+++ b/dim_checks/mozdata/firefox_desktop/active_users_aggregates/dim_checks.yaml
@@ -32,7 +32,7 @@ dim_config:
           query: |
             WITH base AS (
               SELECT client_id
-              FROM `moz-fx-data-shared-prod.telemetry_live.main_v4`
+              FROM `moz-fx-data-shared-prod.telemetry_live.main_v5`
               WHERE
                 DATE(submission_timestamp) = "{{ params.partition }}"
                 AND normalized_app_name = 'Firefox'
@@ -72,7 +72,7 @@ dim_config:
                     payload.simple_measurements.active_ticks
                   )) AS active_ticks
               FROM
-                  `moz-fx-data-shared-prod.telemetry_live.main_v4`
+                  `moz-fx-data-shared-prod.telemetry_live.main_v5`
               WHERE
                 DATE(submission_timestamp) = "{{ params.partition }}"
                 AND normalized_app_name = 'Firefox'


### PR DESCRIPTION
`main_v4` has been deprecated is no longer getting updated.

This should fix the large dim check discrepancy for `firefox_desktop.active_users_aggregates` on 2023-11-14 ([bug 1864727](https://bugzilla.mozilla.org/show_bug.cgi?id=1864727)).